### PR TITLE
Maintenance to scripts

### DIFF
--- a/.github/workflows/docs-preview-pr-common.yaml
+++ b/.github/workflows/docs-preview-pr-common.yaml
@@ -27,14 +27,14 @@ jobs:
       - name: Check for GitHub Pages
         id: api-resp
         run: |
-            has_pages=$(gh api repos/{owner}/{repo} -q '.has_pages')
+            has_pages=$(gh api "repos/${GITHUB_REPOSITORY}" -q '.has_pages')
             if [ "true" != "${has_pages}" ]; then
               echo "GitHub pages is not active for the repository. Quitting."
               return
             fi
 
-            url=$(gh api repos/{owner}/{repo}/pages -q '.html_url')
-            branch=$(gh api repos/{owner}/{repo}/pages -q '.source.branch')
+            url=$(gh api "repos/${GITHUB_REPOSITORY}/pages" -q '.html_url')
+            branch=$(gh api "repos/${GITHUB_REPOSITORY}/pages" -q '.source.branch')
 
             echo "::set-output name=html_url::${url}"
             echo "::set-output name=branch::${branch}"
@@ -45,7 +45,7 @@ jobs:
     needs: [get-gh-pages-url]
     if: needs.get-gh-pages-url.outputs.url != ''
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ needs.get-gh-pages-url.outputs.branch }}
       - name: Initialize Git configuration

--- a/.github/workflows/docs-remove-stale-reviews-common.yaml
+++ b/.github/workflows/docs-remove-stale-reviews-common.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: "gh-pages"
       - name: Initialize Git configuration
@@ -31,6 +31,10 @@ jobs:
       - name: Remove stale reviews
         shell: bash
         run: |
+          if [ ! -d "review" ]; then
+            echo "No reviews exist."
+            exit 0
+          fi
           open=$(gh pr list -L 200 -s open --json 'number' -q '.[]|.pr = "pr-\(.number)"|.pr')
           reviews=$(ls review/)
           for i in ${reviews}; do


### PR DESCRIPTION
* Update actions to newer NodeJS versions.
* For stale reviews, check that the review dir exists. Exit if not.
* Update docs-preview-pr to use env vars for the repo to query. Previously, the prob was that `gh` needed the repo checked out.