### PR TITLE
Branch Name Action - For branch selection for tests

### DIFF
--- a/actions/branch-name/Dockerfile
+++ b/actions/branch-name/Dockerfile
@@ -1,0 +1,8 @@
+# Container image that runs your code
+FROM alpine:3.10
+
+# Copies your code file from your action repository to the filesystem path `/` of the container
+COPY entrypoint.sh /entrypoint.sh
+
+# Code file to execute when the docker container starts up (`entrypoint.sh`)
+ENTRYPOINT ["/entrypoint.sh"]

--- a/actions/branch-name/Dockerfile
+++ b/actions/branch-name/Dockerfile
@@ -1,5 +1,7 @@
 # Container image that runs your code
-FROM alpine:3.10
+FROM alpine:3.17
+
+RUN apk add git
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/actions/branch-name/README.md
+++ b/actions/branch-name/README.md
@@ -1,0 +1,27 @@
+# Branch Name Action
+
+This action finds the branch name to run tests for depending on whether the action is a tag or branch.
+
+## Inputs
+
+## `release-branch-prefix`
+
+The prefix of the release branch. Default `"release"`.
+
+Workflows running on tags are expected to to match branch with this prefix.
+
+## Outputs
+
+## `branch`
+
+The name of the branch we should run tests against.
+
+In the case of a tag, should be a branch with prefix `${release-branch-prefix}`.
+
+For a pull request build. will return the name of the base branch the pull request targets.
+
+## Example usage
+
+```yaml
+uses: NVIDIA-Merlin/.github/actions/branch-name@main
+```

--- a/actions/branch-name/README.md
+++ b/actions/branch-name/README.md
@@ -25,7 +25,7 @@ For a pull request build. will return the name of the base branch the pull reque
 ```yaml
 - name: Get Branch name
   id: get-branch-name
-  uses: NVIDIA-Merlin/.github/actions/branch-name@branch-name
+  uses: NVIDIA-Merlin/.github/actions/branch-name@main
 
 - name: Use the branch name
   run: |

--- a/actions/branch-name/README.md
+++ b/actions/branch-name/README.md
@@ -37,7 +37,8 @@ In the case of a tag build we don't have access to the branch name without perfo
 The reason we need to find the release branch name corresponding to the tag is so that we can run the tests with the corresponding versions of other packges in our ecosystem that we depend on.
 
 - tag
-  - the build for a tag on `release-23.02` returns branch `release-23.02`
+  - the build for a tag on branch `release-23.02` returns branch `release-23.02`
+  - the build for a tag on branch `xyz` returns an error because the branch doesn't start with `{release-branch-prefix}`
 - pull request
   - the build for a pull_request with base branch `main` returns branch `main`
   - the build for a pull request with base branch `release-23.02` returns branch `release-23.02`

--- a/actions/branch-name/README.md
+++ b/actions/branch-name/README.md
@@ -23,5 +23,24 @@ For a pull request build. will return the name of the base branch the pull reque
 ## Example usage
 
 ```yaml
-uses: NVIDIA-Merlin/.github/actions/branch-name@main
+- name: Get Branch name
+  id: get-branch-name
+  uses: NVIDIA-Merlin/.github/actions/branch-name@branch-name
+
+- name: Use the branch name
+  run: |
+    echo "${{ steps.get-branch-name.outputs.branch }}"
 ```
+
+The main complexity and the reason this Action exists comes from the case of a workflow triggered by a tag.
+In the case of a tag build we don't have access to the branch name without performing some additional git commands.
+The reason we need to find the release branch name corresponding to the tag is so that we can run the tests with the corresponding versions of other packges in our ecosystem that we depend on.
+
+- tag
+  - the build for a tag on `release-23.02` returns branch `release-23.02`
+- pull request
+  - the build for a pull_request with base branch `main` returns branch `main`
+  - the build for a pull request with base branch `release-23.02` returns branch `release-23.02`
+- merge commit
+  - the build for a push to branch `main` (following a merge of a PR) returns branch `main`
+  - the build for a push to branch `release-23.02` (following a merge of a PR) returns branch `release-23.02`

--- a/actions/branch-name/action.yml
+++ b/actions/branch-name/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: false
     default: 'release'
 outputs:
-  branch-name:
+  branch:
     description: 'The name of the branch'
 runs:
   using: 'docker'

--- a/actions/branch-name/action.yml
+++ b/actions/branch-name/action.yml
@@ -1,0 +1,16 @@
+# action.yml
+name: 'Branch Name'
+description: 'Get the Branch Name to use for tests'
+inputs:
+  release-branch-prefix:
+    description: 'The prefix of the release branch'
+    required: false
+    default: 'release'
+outputs:
+  branch-name:
+    description: 'The name of the branch'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.release-branch-prefix }}

--- a/actions/branch-name/entrypoint.sh
+++ b/actions/branch-name/entrypoint.sh
@@ -1,0 +1,53 @@
+#!/bin/sh -l
+
+release_branch_prefix=$1
+
+branch=""
+
+if [[ "${GITHUB_REF_TYPE}" == "tag" ]]
+then
+    release_branch_pattern="*${release_branch_prefix}*"
+    remote_name="origin"
+    release_branch_refspec="+refs/heads/${release_branch_prefix}*:refs/remotes/${remote_name}/${release_branch_prefix}*"
+    # fetch release branches (the branch name is not automatically fetched by the actions/checkout step)
+    git -c protocol.version=2 fetch \
+        --no-tags \
+        --prune \
+        --progress \
+        --no-recurse-submodules \
+        --depth=1 \
+        "${remote_name}" "${release_branch_refspec}"
+
+    # find the release branch that we're pointing at
+    branch=$(
+        git branch \
+            --contains "${GITHUB_REF_NAME}" \
+            --list "${release_branch_pattern}"  \
+            --format "%(refname:short)" \
+            | sed -e 's/^origin\///'
+          )
+    if [[ -z "${branch}" ]]
+    then
+        cat <<EOF
+::error::Could not find release branch corresponding to tag '${GITHUB_REF_NAME}'.
+Please check that the tag points to a commit on a branch with prefix '${release_branch_prefix}'
+EOF
+        exit 1
+    fi
+elif [[ "${GITHUB_REF_TYPE}" == "branch" ]]
+then
+    branch="${GITHUB_BASE_REF}"
+    if [[ -z "${branch}" ]]
+    then
+        cat <<EOF
+::error::Running branch build where `GITHUB_BASE_REF` is not set (not a pull request).
+This action currently supports only builds on tags or pull requests.
+EOF
+    fi
+else
+    cat <<EOF
+::error::GITHUB_REF_TYPE must be one of 'branch' or 'tag'. Found '${GITHUB_REF_TYPE}'
+EOF
+fi
+
+echo "branch=$branch" #>> $GITHUB_OUTPUT

--- a/actions/branch-name/entrypoint.sh
+++ b/actions/branch-name/entrypoint.sh
@@ -8,6 +8,9 @@ if [[ "${GITHUB_REF_TYPE}" == "tag" ]]
 then
     remote_name="origin"
     release_branch_refspec="+refs/heads/${release_branch_prefix}*:refs/remotes/${remote_name}/${release_branch_prefix}*"
+
+    git config --global --add safe.directory /github/workspace
+
     # fetch release branches (the branch name is not automatically fetched by the actions/checkout step)
     git -c protocol.version=2 fetch \
         --no-tags \

--- a/actions/branch-name/entrypoint.sh
+++ b/actions/branch-name/entrypoint.sh
@@ -39,12 +39,11 @@ EOF
     fi
 elif [[ "${GITHUB_REF_TYPE}" == "branch" ]]
 then
-    branch="${GITHUB_BASE_REF}"
+    branch="${GITHUB_BASE_REF:-$GITHUB_REF_NAME}"
     if [[ -z "${branch}" ]]
     then
         cat <<EOF
-::error::Running branch build where env var GITHUB_BASE_REF is not set (not a pull request).
-This action currently supports only builds on tags or pull requests.
+::error::Running branch build where and could not find a branch name from either GITHUB_BASE_REF (pull request) or GITHUB_REF_NAME (merge commit)
 EOF
         exit 1
     fi

--- a/actions/branch-name/entrypoint.sh
+++ b/actions/branch-name/entrypoint.sh
@@ -6,7 +6,6 @@ branch=""
 
 if [[ "${GITHUB_REF_TYPE}" == "tag" ]]
 then
-    release_branch_pattern="*${release_branch_prefix}*"
     remote_name="origin"
     release_branch_refspec="+refs/heads/${release_branch_prefix}*:refs/remotes/${remote_name}/${release_branch_prefix}*"
     # fetch release branches (the branch name is not automatically fetched by the actions/checkout step)
@@ -22,7 +21,7 @@ then
     branch=$(
         git branch \
             --contains "${GITHUB_REF_NAME}" \
-            --list "${release_branch_pattern}"  \
+            --list "*${release_branch_prefix}*"  \
             --format "%(refname:short)" \
             | sed -e 's/^origin\///'
           )

--- a/actions/branch-name/entrypoint.sh
+++ b/actions/branch-name/entrypoint.sh
@@ -49,4 +49,4 @@ else
 EOF
 fi
 
-echo "branch=$branch" #>> $GITHUB_OUTPUT
+echo "branch=$branch" >> $GITHUB_OUTPUT

--- a/actions/branch-name/entrypoint.sh
+++ b/actions/branch-name/entrypoint.sh
@@ -23,6 +23,7 @@ then
     # find the release branch that we're pointing at
     branch=$(
         git branch \
+            --remotes \
             --contains "${GITHUB_REF_NAME}" \
             --list "*${release_branch_prefix}*"  \
             --format "%(refname:short)" \

--- a/actions/branch-name/entrypoint.sh
+++ b/actions/branch-name/entrypoint.sh
@@ -42,11 +42,13 @@ then
 ::error::Running branch build where `GITHUB_BASE_REF` is not set (not a pull request).
 This action currently supports only builds on tags or pull requests.
 EOF
+        exit 1
     fi
 else
     cat <<EOF
 ::error::GITHUB_REF_TYPE must be one of 'branch' or 'tag'. Found '${GITHUB_REF_TYPE}'
 EOF
+    exit 1
 fi
 
 echo "branch=$branch" >> $GITHUB_OUTPUT

--- a/actions/branch-name/entrypoint.sh
+++ b/actions/branch-name/entrypoint.sh
@@ -39,7 +39,7 @@ then
     if [[ -z "${branch}" ]]
     then
         cat <<EOF
-::error::Running branch build where `GITHUB_BASE_REF` is not set (not a pull request).
+::error::Running branch build where env var GITHUB_BASE_REF is not set (not a pull request).
 This action currently supports only builds on tags or pull requests.
 EOF
         exit 1


### PR DESCRIPTION
Adds a GitHub Action that can be used in workflows to extract the branch name to use for testing Merlin projects with the same release (e.g. 23.02 `release-23.02` or development - `main`).

This has been extracted and exended from the code we currently run in our workflows. This part for example:

https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/5f7efb7756578689cd25c72c059c7d0ad8e04b06/.github/workflows/ci.yml#L37-L48 

Extended to return clearer error messages about what went wrong. For example, if we make a tag on a commit in the development branch (`main`) accidentally instead of the release branch, this prints an error and causes the step to fail.