### PR TITLE
set mutation field name in 'value' for triage issues action

### DIFF
--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -105,7 +105,7 @@ jobs:
                 projectId: $project
                 itemId: $item
                 fieldId: $impact_field
-                value: $impact_value
+                value: {text: $impact_value}
               }) {
                 projectV2Item {
                   id


### PR DESCRIPTION
There is a syntax error with this mutation - the schema we provide needs more detail. We fixed this for `date` types but when updating the `impact` for issues posted by external users, it fails. `impact` is a text field, so this will hopefully post properly.