### PR TITLE
Add reusable workflow for creating dev tags

### DIFF
--- a/.github/workflows/create-dev-tag.yaml
+++ b/.github/workflows/create-dev-tag.yaml
@@ -11,7 +11,7 @@ name: Create Dev Tag
 #   create-dev-tag:
 #     permissions:
 #       contents: write
-#     uses: NVIDIA-Merlin/.github/.github/workflows/dev-tag.yaml@main
+#     uses: NVIDIA-Merlin/.github/.github/workflows/create-dev-tag.yaml@main
 
 on:
   workflow_call:

--- a/.github/workflows/create-dev-tag.yaml
+++ b/.github/workflows/create-dev-tag.yaml
@@ -40,4 +40,4 @@ jobs:
         run: |
           ref="refs/tags/v${{ steps.next_release.outputs.VERSION }}.dev0"
           git update-ref "${ref}" "${{ github.sha }}"
-          git push -f origin "${ref}"
+          git push origin "${ref}"

--- a/.github/workflows/create-dev-tag.yaml
+++ b/.github/workflows/create-dev-tag.yaml
@@ -1,9 +1,20 @@
 name: Create Dev Tag
 
+# Expected usage in parent workflow
+#
+# on:
+#   push:
+#     branches:
+#       - 'release-[0-9]+.[0-9]+'
+#
+# jobs:
+#   create-dev-tag:
+#     permissions:
+#       contents: write
+#     uses: NVIDIA-Merlin/.github/.github/workflows/dev-tag.yaml@main
+
 on:
-  push:
-    branches:
-      - 'release-[0-9]+.[0-9]+'
+  workflow_call:
 
 jobs:
   create-tag:

--- a/.github/workflows/create-dev-tag.yaml
+++ b/.github/workflows/create-dev-tag.yaml
@@ -1,0 +1,32 @@
+name: Create Dev Tag
+
+on:
+  push:
+    branches:
+      - 'release-[0-9]+.[0-9]+'
+
+jobs:
+  create-tag:
+    if: github.event.created
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract next release version
+        id: next_release
+        run: |
+          version_year=$(echo ${{ github.ref_name }}  | perl -lane 'print m/(\d+).\d+/g')
+          version_month=$(echo ${{ github.ref_name }}  | perl -lane 'print m/\d+.(\d+)/g')
+          if [ "$version_month" == "12" ]; then
+              version_year=$((version_year + 1))
+          fi
+          version_month=$((version_month % 12))
+          version_month=$((version_month + 1))
+          version_month=$(printf "%02d" $version_month)
+          echo "VERSION=$version_year.$version_month" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@v3
+      - name: Push dev tag
+        run: |
+          ref="refs/tags/v${{ steps.next_release.outputs.VERSION }}.dev0"
+          git update-ref "${ref}" "${{ github.sha }}"
+          git push -f origin "${ref}"


### PR DESCRIPTION
Add Reusable workflow for creating dev tags when a release branch is created.

## Example Usage 

```yaml
name: "Create Dev Tag"

on:
  push:
    branches:
      - 'release-[0-9]+.[0-9]+'

jobs:
  create-dev-tag:
    permissions:
      contents: write
    uses: NVIDIA-Merlin/.github/.github/workflows/create-dev-tag.yaml@main
```
