### PR TITLE
Maybe set base branch

### DIFF
--- a/.github/workflows/check-base-branch.yml
+++ b/.github/workflows/check-base-branch.yml
@@ -21,6 +21,7 @@ on:
 
 jobs:
   maybe-set:
+    name: Maybe Set Base Branch
     if: github.base_ref == inputs.stable-branch-name
     runs-on: ubuntu-latest
     permissions:
@@ -37,7 +38,7 @@ jobs:
             /repos/${{ github.repository }}/pulls/${{ github.event.number }} \
             -f base='${{ inputs.development-branch-name }}'
   check:
-    name: Require Development Branch
+    name: Require Development Base Branch
     needs: [maybe-set]
     if: ${{ always() }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Extend the `check-base-branch.yaml` workflow with an extra job that set's the base branch of the pull request if the ref corresponds to the stable branch.

This supports changing the default branch of the repos https://github.com/NVIDIA-Merlin/Merlin/issues/866 without creating too much friction when opening new Pull Requests on the stable branch.

Before this maybe set branch  job will run sucessfully, we need to update each repo with the required permissions

```yaml
permissions: 
  pull_request: write
```